### PR TITLE
Increase size of pools and timeout to DB

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,8 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: 20
+  timeout: 10000
 
 development:
   <<: *default


### PR DESCRIPTION
## Problems
- Raise `ActiveRecord::ConnectionTimeoutError: could not obtain a connection from the pool within 5.000 seconds (waited 5.004 seconds); all pooled connections were in use` if have lots of jobs running asynchronous (cause because I change the way to scrapping data from batches to individually)
## Describe your changes
- Increase the size of connection pools to DB
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
